### PR TITLE
chore(types): make types stricter

### DIFF
--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -52,7 +52,7 @@ export default abstract class Storage {
 	 *
 	 * Supported drivers: "local", "s3", "gcs"
 	 */
-	public driver(): any {
+	public driver(): unknown {
 		throw new MethodNotSupported('driver', this.constructor.name);
 	}
 

--- a/src/StorageManager.ts
+++ b/src/StorageManager.ts
@@ -8,32 +8,30 @@
 import Drivers from './Drivers';
 import Storage from './Storage';
 import { InvalidConfig, DriverNotSupported } from './Exceptions';
+import { StorageManagerConfig, StorageManagerDiskConfig } from './types';
 
 export default class StorageManager {
 	/**
 	 * Configuration of the storage manager.
 	 */
-	private _config: any;
+	private _config: StorageManagerConfig;
+
+	private _disks: StorageManagerDiskConfig;
 
 	/**
 	 * List of drivers extended
 	 */
 	private _extendedDrivers: Map<string, () => Storage> = new Map();
 
-	constructor(config) {
+	constructor(config: StorageManagerConfig) {
 		this._config = config;
-
-		/**
-		 * Adding empty disk property to make future checks
-		 * simpler
-		 */
-		this._config.disks = this._config.disks || {};
+		this._disks = config.disks || {};
 	}
 
 	/**
 	 * Get a disk instance.
 	 */
-	disk<T extends Storage>(name?: string, config?: any): T {
+	disk<T extends Storage>(name?: string, config?: unknown): T {
 		name = name || this._config.default;
 
 		/**
@@ -44,7 +42,7 @@ export default class StorageManager {
 			throw InvalidConfig.missingDiskName();
 		}
 
-		const diskConfig = this._config.disks[name];
+		const diskConfig = this._disks[name];
 
 		/**
 		 * Configuration for the defined disk is missing
@@ -85,7 +83,7 @@ export default class StorageManager {
 	/**
 	 * Register a custom driver.
 	 */
-	public extend<T extends Storage>(name: string, handler: () => T) {
+	public extend<T extends Storage>(name: string, handler: () => T): void {
 		this._extendedDrivers.set(name, handler);
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 export { default as Storage } from './Storage';
 export { default as StorageManager } from './StorageManager';
+export * from './types';
 
-// export drivers and types
+// export drivers and their types
 export * from './Drivers/AWSS3';
 export * from './Drivers/GoogleCloudStorage';
 export * from './Drivers/LocalFileSystem';

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,23 @@
  * @copyright Slynova - Romain Lanz <romain.lanz@slynova.ch>
  */
 
+export interface StorageManagerDiskConfig {
+	[key: string]: {
+		driver: string;
+		[key: string]: unknown;
+	};
+}
+
+export interface StorageManagerConfig {
+	/**
+	 * The default disk returned by `disk()`.
+	 */
+	default?: string;
+	disks?: StorageManagerDiskConfig;
+}
+
 export interface Response {
-	raw: any;
+	raw: unknown;
 }
 
 export interface ExistsResponse extends Response {

--- a/test/unit/storage-manager.spec.ts
+++ b/test/unit/storage-manager.spec.ts
@@ -31,6 +31,7 @@ test.group('Storage Manager', (group) => {
 		const storageManager = new StorageManager({
 			default: 'local',
 			disks: {
+				// @ts-ignore
 				local: {
 					root: '',
 				},


### PR DESCRIPTION
Avoid `any` in public interfaces.
Add missing types for StorageManager.