### PR TITLE
fix: add original stack trace to UnknownException message

### DIFF
--- a/src/Drivers/AWSS3.ts
+++ b/src/Drivers/AWSS3.ts
@@ -18,7 +18,7 @@ function handleError(err: Error, path: string, bucket: string): never {
 		case 'NoSuchKey':
 			throw new FileNotFound(err, path);
 		default:
-			throw new UnknownException(err, path);
+			throw new UnknownException(err, err.name, path);
 	}
 }
 

--- a/src/Drivers/GoogleCloudStorage.ts
+++ b/src/Drivers/GoogleCloudStorage.ts
@@ -19,7 +19,7 @@ function handleError(err: Error & { code?: number }, path: string): never {
 		case 404:
 			throw new FileNotFound(err, path);
 		default:
-			throw new UnknownException(err, path);
+			throw new UnknownException(err, String(err.code), path);
 	}
 }
 

--- a/src/Drivers/LocalFileSystem.ts
+++ b/src/Drivers/LocalFileSystem.ts
@@ -21,7 +21,7 @@ function handleError(err: Error & { code: string; path?: string }, fullPath: str
 		case 'EPERM':
 			throw new PermissionMissing(err, err.path || fullPath);
 		default:
-			throw new UnknownException(err, err.path || fullPath);
+			throw new UnknownException(err, err.code, err.path || fullPath);
 	}
 }
 

--- a/src/Exceptions/UnknownException.ts
+++ b/src/Exceptions/UnknownException.ts
@@ -9,11 +9,12 @@ import { RuntimeException } from 'node-exceptions';
 
 export class UnknownException extends RuntimeException {
 	raw: Error;
-	constructor(err: Error, path: string) {
+	constructor(err: Error, errorCode: string, path: string) {
 		super(
 			`An unknown error happened with the file ${path}.
 Please open an issue at https://github.com/Slynova-Org/flydrive/issues
 
+Error code: ${errorCode}
 Original stack:
 ${err.stack}`,
 			500,

--- a/src/Exceptions/UnknownException.ts
+++ b/src/Exceptions/UnknownException.ts
@@ -11,7 +11,11 @@ export class UnknownException extends RuntimeException {
 	raw: Error;
 	constructor(err: Error, path: string) {
 		super(
-			`An unknown error happened with the file ${path}. Please open an issue at https://github.com/Slynova-Org/flydrive/issues`,
+			`An unknown error happened with the file ${path}.
+Please open an issue at https://github.com/Slynova-Org/flydrive/issues
+
+Original stack:
+${err.stack}`,
 			500,
 			'E_UNKNOWN'
 		);


### PR DESCRIPTION
By default, Node.js doesn't print extra properties of errors,
so the `raw` error is not printed.
Add the stack trace to the error message so people see it and can
paste it to the issue tracker.

Example from local test run without the GCS test key:
```
✖ GCS Driver
  (beforeEach) UnknownException: E_UNKNOWN: An unknown error happened with the file 04a8edb1-2997-41bb-a0e9-1f623ffc5915/test.txt.
Please open an issue at https://github.com/Slynova-Org/flydrive/issues

Error code: 401
Original stack:
Error: Anonymous caller does not have storage.objects.create access to flydrive-test/04a8edb1-2997-41bb-a0e9-1f623ffc5915/test.txt.
    at Util.parseHttpRespBody (/home/mzasso/git/forks/flydrive/node_modules/@google-cloud/common/build/src/util.js:194:38)
    at Util.handleResp (/home/mzasso/git/forks/flydrive/node_modules/@google-cloud/common/build/src/util.js:135:117)
    at /home/mzasso/git/forks/flydrive/node_modules/@google-cloud/common/build/src/util.js:420:22
    at onResponse (/home/mzasso/git/forks/flydrive/node_modules/retry-request/index.js:206:7)
    at /home/mzasso/git/forks/flydrive/node_modules/teeny-request/src/index.ts:254:13
    at processTicksAndRejections (internal/process/task_queues.js:85:5)
    at handleError (/home/mzasso/git/forks/flydrive/src/Drivers/GoogleCloudStorage.ts:22:10)
    at GoogleCloudStorage.put (/home/mzasso/git/forks/flydrive/src/Drivers/GoogleCloudStorage.ts:199:11)
    at processTicksAndRejections (internal/process/task_queues.js:85:5)
```