### PR TITLE
chore(actions): do not add GITHUB_ACTION to env

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,5 +25,4 @@ jobs:
           yarn test:local
           yarn lint
         env:
-          GITHUB_ACTION: true
           GCS_KEY: ${{secrets.GCS_KEY}}


### PR DESCRIPTION
We don't need to do that. GitHub already sets this variable.
https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-actions#default-environment-variables