### PR TITLE
fix: adapt LocalFileSystem to work with Node.js 13

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,6 +6,18 @@ on:
       - develop
   pull_request:
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Install dependencies
+        run: yarn
+      - name: Run ESLint
+        run: yarn lint
   test:
     runs-on: ubuntu-latest
     services:
@@ -21,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 13.x]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
@@ -31,9 +43,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: |
-          yarn test:local
-          yarn lint
+        run: yarn test:local
         env:
           GCS_KEY: ${{secrets.GCS_KEY}}
           S3_KEY: no_need

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "create-output-stream": "^0.0.1",
     "fs-extra": "^8.1.0",
     "node-exceptions": "^4.0.1"
   },

--- a/src/Drivers/LocalFileSystem.ts
+++ b/src/Drivers/LocalFileSystem.ts
@@ -6,9 +6,8 @@
  */
 
 import { Readable } from 'stream';
-import { isAbsolute, join, resolve } from 'path';
+import { dirname, isAbsolute, join, resolve } from 'path';
 import fs from 'fs-extra';
-import createOutputStream from 'create-output-stream';
 import Storage from '../Storage';
 import { FileNotFound, UnknownException, PermissionMissing } from '../Exceptions';
 import { isReadableStream, pipeline } from '../utils';
@@ -204,7 +203,9 @@ export class LocalFileSystem extends Storage {
 
 		try {
 			if (isReadableStream(content)) {
-				const ws = createOutputStream(fullPath, options);
+				const dir = dirname(fullPath);
+				await fs.ensureDir(dir);
+				const ws = fs.createWriteStream(fullPath, options);
 				await pipeline(content, ws);
 				return { raw: undefined };
 			}

--- a/yarn.lock
+++ b/yarn.lock
@@ -668,13 +668,6 @@ cosmiconfig@^5.2.1:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-create-output-stream@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/create-output-stream/-/create-output-stream-0.0.1.tgz#e0ac31e27defeae0e4f699c0edb9c6558c9fa5ab"
-  integrity sha1-4Kwx4n3v6uDk9pnA7bnGVYyfpas=
-  dependencies:
-    mkdirp "^0.5.1"
-
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"


### PR DESCRIPTION
`create-output-stream` hacks into fs.WriteStream in a way that is not
supported anymore by Node.js.
Remove it and create directories ourselves as it was the sole purpose of
the library.