### PR TITLE
refactor: do not expose drivers in package main

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,3 @@
 export { default as Storage } from './Storage';
 export { default as StorageManager } from './StorageManager';
 export * from './types';
-
-// export drivers and their types
-export * from './Drivers/AWSS3';
-export * from './Drivers/GoogleCloudStorage';
-export * from './Drivers/LocalFileSystem';


### PR DESCRIPTION
This breaks TypeScript users because the types add a hard dependency on
both `aws-sdk` and `@google-cloud/storage` even if they are not used.