### PR TITLE
[LocalFileSystem] Fix wrong variable name in move method

### DIFF
--- a/src/Drivers/LocalFileSystem.ts
+++ b/src/Drivers/LocalFileSystem.ts
@@ -170,7 +170,7 @@ export class LocalFileSystem extends Storage {
 		const srcPath = this._fullPath(src);
 
 		try {
-			const result = await fs.move(src, this._fullPath(dest));
+			const result = await fs.move(srcPath, this._fullPath(dest));
 			return { raw: result };
 		} catch (e) {
 			return handleError(e, srcPath);


### PR DESCRIPTION
`LocalFileSystem` has a mistake when call `fs.move(src` instead of `fs.move(srcPath`, you created `srcPath` but never use