### PR TITLE
feat: default storage manager in main export

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@google-cloud/storage": "^4.0.0",
     "@types/fs-extra": "^8.0.1",
-    "@types/node": "10.0.0",
+    "@types/node": "10.17.5",
     "@typescript-eslint/eslint-plugin": "^2.5.0",
     "@typescript-eslint/parser": "^2.5.0",
     "aws-sdk": "^2.553.0",

--- a/src/Drivers/AWSS3.ts
+++ b/src/Drivers/AWSS3.ts
@@ -7,7 +7,7 @@
 
 import { Readable } from 'stream';
 import S3, { ClientConfiguration } from 'aws-sdk/clients/s3';
-import { Storage } from '..';
+import Storage from '../Storage';
 import { UnknownException, NoSuchBucket, FileNotFound } from '../Exceptions';
 import { SignedUrlOptions, Response, ExistsResponse, ContentResponse, SignedUrlResponse, StatResponse } from '../types';
 

--- a/src/StorageManager.ts
+++ b/src/StorageManager.ts
@@ -23,7 +23,14 @@ export default class StorageManager {
 	 */
 	private _extendedDrivers: Map<string, () => Storage> = new Map();
 
-	constructor(config: StorageManagerConfig) {
+	constructor(config?: StorageManagerConfig) {
+		this.config(config || {});
+	}
+
+	/**
+	 * set the configuration
+	 */
+	config (config: StorageManagerConfig) {
 		this._config = config;
 		this._disks = config.disks || {};
 	}
@@ -31,7 +38,7 @@ export default class StorageManager {
 	/**
 	 * Get a disk instance.
 	 */
-	disk<T extends Storage>(name?: string, config?: unknown): T {
+	disk<T extends Storage>(name?: string, config: object = {}): T {
 		name = name || this._config.default;
 
 		/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import StorageManager from "./StorageManager";
+
 export { default as Storage } from './Storage';
 export { default as StorageManager } from './StorageManager';
+export const manager = new StorageManager();
 export * from './types';

--- a/test/unit/storage-manager.spec.ts
+++ b/test/unit/storage-manager.spec.ts
@@ -37,7 +37,7 @@ test.group('Storage Manager', (group) => {
 					root: '',
 				},
 			},
-		});
+		} as any);
 		const fn = () => storageManager.disk();
 		assert.throw(fn, 'E_INVALID_CONFIG: Make sure to define driver for local disk');
 	});


### PR DESCRIPTION
Added a default storage manager to main export, as well as a config() method for the StorageManager class in order to reconfigure the default storage manager without reinstantiating. This allows callers to do storage manager setup once at application start and reuse the same instances without needing to require() a separate file where a configured StorageManager has been set up. This is a similar pattern to how popular database and logging libraries export default containers for connections or loggers. Seeing as storage drivers fall under a similar class of reusability throughout an application, use of this pattern seems appropriate in this library.

Note: upgraded @types/node to version 10.17.5 to fix build issues (kept version fixed as it was previously).