### PR TITLE
Change domain of GCP public access URL

### DIFF
--- a/src/Drivers/GoogleCloudStorage.ts
+++ b/src/Drivers/GoogleCloudStorage.ts
@@ -174,7 +174,7 @@ export class GoogleCloudStorage extends Storage {
 	 * status.
 	 */
 	public getUrl(location: string): string {
-		return `https://storage.cloud.google.com/${this.$bucket.name}/${location}`;
+		return `https://storage.googleapis.com/${this.$bucket.name}/${location}`;
 	}
 
 	/**


### PR DESCRIPTION
I am not sure if this is the intention of the method `getUrl`.

**My UseCase**
I am looking for a publicly accessible url for a public object in GCS bucket.