### PR TITLE
Export local storage driver class

### DIFF
--- a/packages/flydrive/src/index.ts
+++ b/packages/flydrive/src/index.ts
@@ -7,6 +7,7 @@
 
 export { default as Storage } from './Storage';
 export { default as StorageManager } from './StorageManager';
+export { LocalFileSystemStorage } from './LocalFileSystemStorage';
 
 export * from './exceptions';
 export * from './utils';

--- a/packages/flydrive/src/types.ts
+++ b/packages/flydrive/src/types.ts
@@ -5,9 +5,9 @@
  * @copyright Slynova - Romain Lanz <romain.lanz@slynova.ch>
  */
 
-import { LocalFileSystemStorage, LocalFileSystemStorageConfig } from './LocalFileSystemStorage';
+import { LocalFileSystemStorageConfig } from './LocalFileSystemStorage';
 
-export type { LocalFileSystemStorage, LocalFileSystemStorageConfig };
+export type { LocalFileSystemStorageConfig };
 
 export type StorageManagerSingleDiskConfig =
 	| {


### PR DESCRIPTION
`LocalFileSystemStorage` was a exported as a type and I got this error.
<img width="651" alt="image" src="https://user-images.githubusercontent.com/4995501/84587616-773f5280-ae40-11ea-83a7-ff8def6e7c8c.png">

This PR exports the class as a value instead.