### PR TITLE
Replace Readable with NodeJS.ReadableStream

### DIFF
--- a/packages/flydrive-gcs/src/GoogleCloudStorage.ts
+++ b/packages/flydrive-gcs/src/GoogleCloudStorage.ts
@@ -5,7 +5,6 @@
  * @copyright Slynova - Romain Lanz <romain.lanz@slynova.ch>
  */
 
-import { Readable } from 'stream';
 import {
 	Storage as GCSDriver,
 	StorageOptions,
@@ -177,7 +176,7 @@ export class GoogleCloudStorage extends Storage {
 	/**
 	 * Returns the stream for the given file.
 	 */
-	public getStream(location: string): Readable {
+	public getStream(location: string): NodeJS.ReadableStream {
 		return this._file(location).createReadStream();
 	}
 
@@ -209,7 +208,7 @@ export class GoogleCloudStorage extends Storage {
 	 * Creates a new file.
 	 * This method will create missing directories on the fly.
 	 */
-	public async put(location: string, content: Buffer | Readable | string): Promise<Response> {
+	public async put(location: string, content: Buffer | NodeJS.ReadableStream | string): Promise<Response> {
 		const file = this._file(location);
 
 		try {

--- a/packages/flydrive-s3/src/AmazonWebServicesS3Storage.ts
+++ b/packages/flydrive-s3/src/AmazonWebServicesS3Storage.ts
@@ -5,7 +5,6 @@
  * @copyright Slynova - Romain Lanz <romain.lanz@slynova.ch>
  */
 
-import { Readable } from 'stream';
 import S3, { ClientConfiguration, ObjectList } from 'aws-sdk/clients/s3';
 import {
 	Storage,
@@ -182,7 +181,7 @@ export class AmazonWebServicesS3Storage extends Storage {
 	/**
 	 * Returns the stream for the given file.
 	 */
-	public getStream(location: string): Readable {
+	public getStream(location: string): NodeJS.ReadableStream {
 		const params = { Key: location, Bucket: this.$bucket };
 
 		return this.$driver.getObject(params).createReadStream();
@@ -216,7 +215,7 @@ export class AmazonWebServicesS3Storage extends Storage {
 	 * Creates a new file.
 	 * This method will create missing directories on the fly.
 	 */
-	public async put(location: string, content: Buffer | Readable | string): Promise<Response> {
+	public async put(location: string, content: Buffer | NodeJS.ReadableStream | string): Promise<Response> {
 		const params = { Key: location, Body: content, Bucket: this.$bucket };
 		try {
 			const result = await this.$driver.upload(params).promise();

--- a/packages/flydrive/src/LocalFileSystemStorage.ts
+++ b/packages/flydrive/src/LocalFileSystemStorage.ts
@@ -6,7 +6,6 @@
  */
 
 import * as fse from 'fs-extra';
-import { Readable } from 'stream';
 import { promises as fs } from 'fs';
 import { dirname, join, resolve, relative, sep } from 'path';
 import Storage from './Storage';
@@ -144,7 +143,7 @@ export class LocalFileSystemStorage extends Storage {
 	/**
 	 * Returns a read stream for a file location.
 	 */
-	public getStream(location: string): Readable {
+	public getStream(location: string): NodeJS.ReadableStream {
 		return fse.createReadStream(this._fullPath(location));
 	}
 
@@ -180,7 +179,7 @@ export class LocalFileSystemStorage extends Storage {
 	 * Creates a new file.
 	 * This method will create missing directories on the fly.
 	 */
-	public async put(location: string, content: Buffer | Readable | string): Promise<Response> {
+	public async put(location: string, content: Buffer | NodeJS.ReadableStream | string): Promise<Response> {
 		const fullPath = this._fullPath(location);
 
 		try {

--- a/packages/flydrive/src/Storage.ts
+++ b/packages/flydrive/src/Storage.ts
@@ -6,7 +6,6 @@
  * @copyright Slynova - Romain Lanz <romain.lanz@slynova.ch>
  */
 
-import { Readable } from 'stream';
 import { MethodNotSupported } from './exceptions';
 import {
 	Response,
@@ -109,7 +108,7 @@ export default abstract class Storage {
 	 *
 	 * Supported drivers: "local", "s3", "gcs"
 	 */
-	getStream(location: string): Readable {
+	getStream(location: string): NodeJS.ReadableStream {
 		throw new MethodNotSupported('getStream', this.constructor.name);
 	}
 
@@ -139,7 +138,7 @@ export default abstract class Storage {
 	 *
 	 * Supported drivers: "local", "s3", "gcs"
 	 */
-	put(location: string, content: Buffer | Readable | string): Promise<Response> {
+	put(location: string, content: Buffer | NodeJS.ReadableStream | string): Promise<Response> {
 		throw new MethodNotSupported('put', this.constructor.name);
 	}
 

--- a/packages/flydrive/src/utils.ts
+++ b/packages/flydrive/src/utils.ts
@@ -6,14 +6,14 @@
  */
 
 import { promisify } from 'util';
-import { Readable, pipeline as nodePipeline } from 'stream';
+import { pipeline as nodePipeline } from 'stream';
 
 /**
  * Returns a boolean indication if stream param
  * is a readable stream or not.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isReadableStream(stream: any): stream is Readable {
+export function isReadableStream(stream: any): stream is NodeJS.ReadableStream {
 	return (
 		stream !== null &&
 		typeof stream === 'object' &&

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,12 +1,10 @@
-import { Readable } from 'stream';
-
 import { Storage } from '../packages/flydrive/src';
 
-export async function streamToString(stream: Readable): Promise<string> {
+export async function streamToString(stream: NodeJS.ReadableStream): Promise<string> {
 	const chunks: string[] = [];
 	stream.setEncoding('utf-8');
 	for await (const chunk of stream) {
-		chunks.push(chunk);
+		chunks.push(chunk as string);
 	}
 	return chunks.join('');
 }


### PR DESCRIPTION
Swaps out the `Readable` type from `stream` for `NodeJS.ReadableStream`, which is more permissive.

Fixes #145 