### PR TITLE
Get method example is using exists instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ This method will return the file's content as a string for the given location.
 ```javascript
 // Supported drivers: "local", "s3", "gcs"
 
-const { content } = await storage.disk('local').exists('foo.txt');
+const { content } = await storage.disk('local').get('foo.txt');
 ```
 
 </details>

--- a/packages/flydrive/README.md
+++ b/packages/flydrive/README.md
@@ -181,7 +181,7 @@ This method will return the file's content as a string for the given location.
 ```javascript
 // Supported drivers: "local", "s3", "gcs"
 
-const { content } = await storage.disk('local').exists('foo.txt');
+const { content } = await storage.disk('local').get('foo.txt');
 ```
 
 </details>


### PR DESCRIPTION
Noticed the description for `get` is using `exists` in the example (instead of `get`)