### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,8 +300,8 @@ This method will return an async iterator over all file names that start with `p
 // Supported drivers: "local", "s3", "gcs"
 
 const disk = storage.disk('local');
-for await (const filename of disk.flatList('a/b')) {
-  console.log(filename);
+for await (const file of disk.flatList('a/b')) {
+  console.log(file.path);
 }
 ```
 


### PR DESCRIPTION
According to the TS definitions, `disk.flatList` returns `FileListResponse` instead of a `string`. `FileListResponse` is an extension of response and contains `path`, so I believe this update makes the readme match the implementation