### PR TITLE
Support putting a publicly readable file to S3 bucket

### DIFF
--- a/packages/flydrive-s3/src/AmazonWebServicesS3Storage.ts
+++ b/packages/flydrive-s3/src/AmazonWebServicesS3Storage.ts
@@ -215,8 +215,8 @@ export class AmazonWebServicesS3Storage extends Storage {
 	 * Creates a new file.
 	 * This method will create missing directories on the fly.
 	 */
-	public async put(location: string, content: Buffer | NodeJS.ReadableStream | string): Promise<Response> {
-		const params = { Key: location, Body: content, Bucket: this.$bucket };
+	public async put(location: string, content: Buffer | NodeJS.ReadableStream | string, makePublic: boolean = false): Promise<Response> {
+		const params = { Key: location, Body: content, Bucket: this.$bucket, ACL: makePublic ? 'public-read' : 'private' };
 		try {
 			const result = await this.$driver.upload(params).promise();
 			return { raw: result };


### PR DESCRIPTION
Add an optional boolean parameter named `makePublic` to the `put()` method. If `makePublic` is public, sets `ACL: 'public-read'` on the params, otherwise sets it to 'private', which is the default behavior. This change is backward compatible.

This PR does not break anything.